### PR TITLE
Migrate transform to Koza 2.x

### DIFF
--- a/download.yaml
+++ b/download.yaml
@@ -4,4 +4,4 @@
 ### For more information, see https://github.com/monarch-initiative/kghub-downloader
 ---
 - url: https://github.com/obophenotype/upheno-dev/raw/refs/heads/master/src/mappings/upheno-cross-species.sssom.tsv
-  local_name: upheno-cross-species.sssom.tsv
+  local_name: data/upheno-cross-species.sssom.tsv

--- a/src/transform.py
+++ b/src/transform.py
@@ -1,51 +1,48 @@
-import koza
-
+import uuid
 from typing import Any
 
+import koza
 from biolink_model.datamodel.pydanticmodel_v2 import (
-    PhenotypicFeature,
+    AgentTypeEnum,
     Association,
     KnowledgeLevelEnum,
-    AgentTypeEnum,
-)  # Replace * with any necessary data classes from the Biolink Model
+    PhenotypicFeature,
+)
+from koza import KozaTransform
 
-from koza.model.graphs import KnowledgeGraph
-from bmt.pydantic import build_association_knowledge_sources
-from bmt.pydantic import entity_id
 
 INFORES_UPHENO = "infores:upheno"
 
-@koza.transform_record(tag=None)
-def transform_upheno(
-        koza_transform: koza.KozaTransform,
-        row: dict[str, Any]
-) -> KnowledgeGraph | None:
-    #if(row['subject_source']=="obo:upheno" or row['object_source']=="obo:upheno"):
-    #    continue
-    
-    subject_phenotype_entity = PhenotypicFeature(
+
+@koza.transform_record()
+def transform_record(koza_transform: KozaTransform, row: dict[str, Any]) -> list:
+    subject_phenotype = PhenotypicFeature(
         id=row["subject_id"],
-        name=row["subject_label"],
+        name=row["subject_label"] or None,
         category=["biolink:PhenotypicFeature"],
     )
-    object_phenotype_entity = PhenotypicFeature(
+    object_phenotype = PhenotypicFeature(
         id=row["object_id"],
-        name=row["object_label"],
+        name=row["object_label"] or None,
         category=["biolink:PhenotypicFeature"],
     )
     association = Association(
-        id=entity_id(),
-        subject=subject_phenotype_entity.id,
+        id=f"urn:uuid:{uuid.uuid4()}",
+        subject=subject_phenotype.id,
         predicate="biolink:homologous_to",
         original_predicate=row["predicate_id"],
-        object=object_phenotype_entity.id,
+        object=object_phenotype.id,
         subject_category="biolink:PhenotypicFeature",
         object_category="biolink:PhenotypicFeature",
         category=["biolink:Association"],
-        primary_knowledge_source="infores:upheno",
+        primary_knowledge_source=INFORES_UPHENO,
         knowledge_source="upheno-cross-species.sssom.tsv",
-        has_attribute=[f'"mapping_justification":"{row["mapping_justification"]}"',f'"subject_source":"{row["subject_source"]}"',f'"object_source":"{row["object_source"]}"'],
+        has_attribute=[
+            f'"mapping_justification":"{row["mapping_justification"]}"',
+            f'"subject_source":"{row["subject_source"]}"',
+            f'"object_source":"{row["object_source"]}"',
+        ],
         knowledge_level=KnowledgeLevelEnum.prediction,
-        agent_type=AgentTypeEnum.data_analysis_pipeline ,
+        agent_type=AgentTypeEnum.data_analysis_pipeline,
     )
-    return KnowledgeGraph(nodes=[subject_phenotype_entity,object_phenotype_entity], edges=[association])
+    return [subject_phenotype, object_phenotype, association]

--- a/src/transform.yaml
+++ b/src/transform.yaml
@@ -1,20 +1,10 @@
-# Config file for transforming data from a source
-# See additional/optional config parameters at https://koza.monarchinitiative.org/Ingests/source_config/
-
-name: "upheno_phenotype_to_phenotype"
-metadata:
-  ingest_title: "upheno_phenotype_to_phenotype"
-
-#metadata: "./src/upheno_cross_species_ingest/metadata.yaml"
+name: 'upheno_phenotype_to_phenotype'
 
 reader:
-  name: "upheno_phenotype_to_phenotype_reader"
-  format: "csv" # Format of the data files (csv or json)
+  format: 'csv'
   delimiter: '\t'
   files:
-    - "../data/upheno-cross-species.sssom.tsv"
-  # For a csv/tsv file, list expected columns
-
+    - '../data/upheno-cross-species.sssom.tsv'
   columns:
     - 'subject_id'
     - 'subject_label'
@@ -24,7 +14,6 @@ reader:
     - 'mapping_justification'
     - 'subject_source'
     - 'object_source'
-
   filters:
     - inclusion: 'exclude'
       column: 'subject_source'
@@ -35,29 +24,19 @@ reader:
       filter_code: 'eq'
       value: 'obo:upheno'
 
-transform:
-  name: "upheno_phenotype_to_phenotype_transform"
-  mode: "flat"
-
 writer:
-  name: "upheno_phenotype_to_phenotype_writer"
   node_properties:
-    # List of node properties to include, if ingesting nodes
-    # Remove if not ingesting nodes
     - id
     - name
     - category
-
   edge_properties:
-    # List of edge properties to include if ingesting edges
-    # Remove if not ingesting edges
     - id
     - subject
     - predicate
     - object
     - subject_category
     - object_category
-    - category        
+    - category
     - primary_knowledge_source
     - knowledge_source
     - knowledge_level


### PR DESCRIPTION
Closes #7. Releases have been failing since 2025-12-07 with KozaConfig validation errors (`Unexpected keyword argument 'name'` for reader and writer). This PR brings the transform onto the Koza 2.x API and produces semantically identical output to the last working release.

## Changes

- transform.yaml: drop the legacy 'name:' fields under reader/writer and remove the entire 'transform:' section. The Koza 2.x defaults (header_mode=infer + comment_char='#') already skip the SSSOM '#' header block — no preprocess step needed.
- transform.py: switch to the @koza.transform_record() pattern that cureid/ctd/mmrrc/reactome already use, return a list of entities instead of the now-removed KnowledgeGraph wrapper, and replace bmt.pydantic.entity_id (which doesn't exist in current bmt) with str(uuid.uuid4()) using the urn:uuid: prefix the previous shipped output used. Drops the unused build_association_knowledge_sources import.
- download.yaml: write the SSSOM file to data/ to match transform.yaml's '../data/...' path. The file had been landing at repo root, which worked when the legacy Makefile drove the download but not after the metadata-wiring PR switched to kghub-downloader.

## Verification (output diff against 2025-12-07 release)

|  | new | baseline (2025-12-07) |
| --- | --- | --- |
| nodes | 17,748 | 17,748 |
| edges | 8,874 | 8,874 |
| nodes content | byte-identical (sorted) | — |
| edges content excluding id | byte-identical (sorted) | — |
| predicate distribution | 8,874 `biolink:homologous_to` | 8,874 `biolink:homologous_to` |
| subject-id prefix distribution | identical | — |
| headers | identical | — |

The only differences are the random uuid in the edge `id` column, which is expected (and matches the legacy behavior of `urn:uuid:...`).